### PR TITLE
Disable synthetic default imports

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import JSON from 'json-typescript';
+import * as JSON from 'json-typescript';
 // tslint:disable-next-line:no-namespace
 
 /*

--- a/tests/errors/main.test.ts
+++ b/tests/errors/main.test.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { check, checkDirectory } from 'typings-tester';
 import { join } from 'path';
 import { assertTsThrows } from '../helpers';
-import JSONAPI from '../../index';
+import * as JSONAPI from '../../index';
 
 @suite('Error Tests')
 class ErrorTests {

--- a/tests/links/main.test.ts
+++ b/tests/links/main.test.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { check, checkDirectory } from 'typings-tester';
 import { join } from 'path';
 import { assertTsThrows } from '../helpers';
-import JSONAPI from '../../index';
+import * as JSONAPI from '../../index';
 
 @suite('Link Tests')
 class LinkTests {

--- a/tests/relationships/main.test.ts
+++ b/tests/relationships/main.test.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { check, checkDirectory } from 'typings-tester';
 import { join } from 'path';
 import { assertTsThrows } from '../helpers';
-import JSONAPI from '../../index';
+import * as JSONAPI from '../../index';
 
 @suite('Relationship objects')
 class RelationshipsTests {

--- a/tests/resources/main.test.ts
+++ b/tests/resources/main.test.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { check, checkDirectory } from 'typings-tester';
 import { join } from 'path';
 import { assertTsThrows } from '../helpers';
-import JSONAPI from '../../index';
+import * as JSONAPI from '../../index';
 
 @suite('Resource objects')
 class ResourceTests {

--- a/tests/toplevel/main.test.ts
+++ b/tests/toplevel/main.test.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { check, checkDirectory } from 'typings-tester';
 import { join } from 'path';
 import { assertTsThrows } from '../helpers';
-import JSONAPI from '../../index';
+import * as JSONAPI from '../../index';
 
 @suite(
 	'Top-Level Document Tests: A JSON object MUST be at the root of every JSON API request and response containing data.'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
 			"es2015"
 		],
 		"noImplicitThis": true,
-		"allowSyntheticDefaultImports": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,
 		"sourceMap": true,


### PR DESCRIPTION
It seems that because this package ships the uncompiled `index.ts` file, the consuming application's Typescript will be compiling this file along with the rest of the application itself. That means the consuming app's tsconfig is used when compiling these types.

Your tsconfig had `"allowSyntheticDefaultImports": true,`, which allows you write something like:

```
import Foo from 'foo';
```

even when the `foo` package doesn't have a default export. This option exists because many (but not all) transpilers add a fake `default` export to CJS modules.

But because the consuming app is the one doing the compiling, if they have chosen to opt out of synthetic defaults (as I have, for example), they will see type errors originating from this file.

This PR removes the synthetic defaults option for this package, and fixes the syntax to not rely on it. The result is that folks with or without the synthetic defaults option should end up seeing no errors from this package.
