### PR TITLE
Type validation for specific resource object types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,8 +14,9 @@ export interface DocWithMeta extends DocBase {
 	meta: MetaObject; // a meta object that contains non-standard meta-information.
 }
 
-export interface DocWithData extends DocBase {
-	data: PrimaryData; // the document’s “primary data”
+export interface DocWithData<T extends PrimaryData = PrimaryData>
+	extends DocBase {
+	data: T; // the document’s “primary data”
 	included?: Included;
 }
 

--- a/index.ts
+++ b/index.ts
@@ -36,6 +36,14 @@ export interface DocBase {
 }
 
 export type Document = DocWithErrors | DocWithMeta | DocWithData;
+export type SingleResourceDoc<
+	T extends string = string,
+	A extends { [k: string]: JSON.Value } = { [k: string]: JSON.Value }
+> = DocWithData<ResourceObject<T, A>>;
+export type CollectionResourceDoc<
+	T extends string = string,
+	A extends { [k: string]: JSON.Value } = { [k: string]: JSON.Value }
+> = DocWithData<Array<ResourceObject<T, A>>>;
 
 // an object describing the server’s implementation
 export interface ImplementationInfo {
@@ -75,22 +83,18 @@ export interface ErrorObject {
 	meta?: MetaObject;
 }
 
-export type PrimaryData = SinglePrimaryData | CollectionPrimaryData;
+export type PrimaryData<
+	T extends string = string,
+	A extends AttributesObject = AttributesObject
+> = ResourceObject<T, A> | Array<ResourceObject<T, A>>;
 
-export type SinglePrimaryData =
-	| null
-	| ResourceObject
-	| ResourceIdentifierObject;
-
-export type CollectionPrimaryData =
-	| never[]
-	| ResourceObject[]
-	| ResourceIdentifierObject[];
-
-export interface ResourceObject {
+export interface ResourceObject<
+	T extends string = string,
+	A extends AttributesObject = AttributesObject
+> {
 	id?: string;
-	type: string;
-	attributes?: AttributesObject;
+	type: T;
+	attributes?: AttributesObject<A>;
 	relationships?: RelationshipsObject;
 	links?: Links;
 	meta?: MetaObject;
@@ -129,8 +133,8 @@ export interface RelationshipsObject {
 	[k: string]: RelationshipObject;
 }
 
-export interface AttributesObject {
-	[k: string]: JSON.Value;
-}
+export type AttributesObject<
+	ATTRS extends { [k: string]: JSON.Value } = { [k: string]: JSON.Value }
+> = { [K in keyof ATTRS]: ATTRS[K] };
 
 export type Errors = ErrorObject[];

--- a/tests/errors/examples/arbitrary-object.ts
+++ b/tests/errors/examples/arbitrary-object.ts
@@ -1,4 +1,4 @@
-import JSONAPI from '../../../index';
+import * as JSONAPI from '../../../index';
 let o: JSONAPI.ErrorObject = {
 	foo: 'bar'
 };

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -2,38 +2,46 @@ import { assert } from 'chai';
 import { check } from 'typings-tester';
 import { join, dirname } from 'path';
 import * as tsconfig from 'tsconfig';
-export async function assertTsThrows(fileName: string, message?: string): Promise<void>;
-export async function assertTsThrows(fileName: string, errType: RegExp|Function, message?: string): Promise<void>;
-export async function assertTsThrows(fileName: string, errType: Function, regExp: RegExp): Promise<void>;
 export async function assertTsThrows(
 	fileName: string,
-  errType?: string | RegExp | Function,
-  message?: string | RegExp
+	message?: string
+): Promise<void>;
+export async function assertTsThrows(
+	fileName: string,
+	errType: RegExp | Function,
+	message?: string
+): Promise<void>;
+export async function assertTsThrows(
+	fileName: string,
+	errType: Function,
+	regExp: RegExp
+): Promise<void>;
+export async function assertTsThrows(
+	fileName: string,
+	errType?: string | RegExp | Function,
+	message?: string | RegExp
 ): Promise<void> {
-  return tsFileAssert(fileName, errType, message, assert.throws);
+	return tsFileAssert(fileName, errType, message, assert.throws);
 }
 async function tsFileAssert(
 	fileName: string,
-  errType?: string | RegExp | Function,
-  message?: string | RegExp,
-  assertMethod = assert.throws
+	errType?: string | RegExp | Function,
+	message?: string | RegExp,
+	assertMethod = assert.throws
 ): Promise<void> {
-  let typescriptConfig = await tsconfig.resolve(dirname(fileName));
-  let cb = () => {
-    check(
-      [fileName],
-      typescriptConfig as string
-    );
-  };
-  if (!errType) {
-    assertMethod(cb);
-  } else if (typeof errType === 'string') {
-    assertMethod(cb, errType);
-  } else if (message && typeof message === 'string') {
-    assertMethod(cb, errType, message);
-  } else if (errType instanceof Function && message instanceof RegExp) {
-    assertMethod(cb, errType, message);
-  } else {
-    assertMethod(cb, errType);
-  }
+	let typescriptConfig = await tsconfig.resolve(dirname(fileName));
+	let cb = () => {
+		check([fileName], typescriptConfig as string);
+	};
+	if (!errType) {
+		assertMethod(cb);
+	} else if (typeof errType === 'string') {
+		assertMethod(cb, errType);
+	} else if (message && typeof message === 'string') {
+		assertMethod(cb, errType, message);
+	} else if (errType instanceof Function && message instanceof RegExp) {
+		assertMethod(cb, errType, message);
+	} else {
+		assertMethod(cb, errType);
+	}
 }

--- a/tests/links/examples/empty-object.ts
+++ b/tests/links/examples/empty-object.ts
@@ -1,2 +1,2 @@
-import JSONAPI from '../../../index';
+import * as JSONAPI from '../../../index';
 let o: JSONAPI.Link = {};

--- a/tests/relationships/examples/empty-object.ts
+++ b/tests/relationships/examples/empty-object.ts
@@ -1,2 +1,2 @@
-import JSONAPI from '../../../index';
+import * as JSONAPI from '../../../index';
 let o: JSONAPI.RelationshipObject = {};

--- a/tests/resources/examples/empty-object.ts
+++ b/tests/resources/examples/empty-object.ts
@@ -1,2 +1,2 @@
-import JSONAPI from '../../../index';
+import * as JSONAPI from '../../../index';
 let o: JSONAPI.ResourceObject = {};

--- a/tests/resources/examples/missing-type.ts
+++ b/tests/resources/examples/missing-type.ts
@@ -1,4 +1,4 @@
-import JSONAPI from '../../../index';
+import * as JSONAPI from '../../../index';
 let o: JSONAPI.ResourceObject = {
 	id: '41'
 };

--- a/tests/resources/main.test.ts
+++ b/tests/resources/main.test.ts
@@ -1,9 +1,7 @@
 import { suite, test, slow, timeout, only } from 'mocha-typescript';
-import { assert } from 'chai';
-import { check, checkDirectory } from 'typings-tester';
 import { join } from 'path';
 import { assertTsThrows } from '../helpers';
-import * as JSONAPI from '../../index';
+import { ResourceObject } from '../..';
 
 @suite('Resource objects')
 class ResourceTests {
@@ -11,7 +9,7 @@ class ResourceTests {
 	async emptyObject() {
 		await assertTsThrows(
 			join(__dirname, 'examples/empty-object.ts'),
-			/is not assignable to type 'ResourceObject'/,
+			/is not assignable to type 'ResourceObject/,
 			'string is not a valid resource object'
 		);
 	}
@@ -20,14 +18,14 @@ class ResourceTests {
 	async hasType() {
 		await assertTsThrows(
 			join(__dirname, 'examples/missing-type.ts'),
-			/is not assignable to type 'ResourceObject'/,
+			/is not assignable to type 'ResourceObject/,
 			'string is not a valid resource object'
 		);
 	}
 
 	@test('A few examples of valid resource objects')
 	validResourceObjects() {
-		let o: JSONAPI.ResourceObject;
+		let o: ResourceObject;
 		o = {
 			type: 'articles',
 			id: '1',

--- a/tests/toplevel/collection-resource-doc.ts
+++ b/tests/toplevel/collection-resource-doc.ts
@@ -1,0 +1,101 @@
+import { suite, test } from 'mocha-typescript';
+import { join } from 'path';
+import { assertTsThrows } from '../helpers';
+import { DocWithData, ResourceObject, CollectionResourceDoc } from '../..';
+
+@suite(
+	'CollectionResourceDoc Tests: Top-level documents that should contain collections of resource objects.'
+)
+class CollectionResourceDocTests {
+	@test('Document with multi resource data')
+	validDocWithCollectionResourceData() {
+		// single resource case
+		let d: DocWithData<ResourceObject[]> = {
+			data: [
+				{
+					type: 'foo'
+				}
+			]
+		};
+	}
+
+	@test(
+		'DocWithData<ResourceObject[]> will throw type error on a single-resource document'
+	)
+	async invalidDocWithCollectionResourceData() {
+		await assertTsThrows(
+			join(__dirname, 'examples/bad-collection-doc.ts'),
+			/is not assignable to type 'DocWithData<ResourceObject</,
+			'Doc that should contain a collection throws if data: is an object'
+		);
+	}
+
+	@test('CollectionResourceDoc for specific type w/o specific attributes')
+	async validCollectionResourceDocWithTypeName() {
+		let d: CollectionResourceDoc<'book'>;
+		d = {
+			data: [
+				{
+					type: 'book',
+					attributes: {
+						foo: 'Great Expectations',
+						bar: 12,
+						baz: 'F. Scott Fitzgerald'
+					}
+				}
+			]
+		};
+	}
+
+	@test('CollectionResourceDoc for specific type w/ specific attributes')
+	async validCollectionResourceDocWithAttrs() {
+		let d: CollectionResourceDoc<
+			'book',
+			{ title: string; author: string; chapters: number }
+		>;
+		d = {
+			data: [
+				{
+					type: 'book',
+					attributes: {
+						title: 'Great Expectations',
+						chapters: 12,
+						author: 'F. Scott Fitzgerald'
+					}
+				}
+			]
+		};
+	}
+
+	@test(
+		'CollectionResourceDoc that specifies resource type name should throw in the presence of resources w/ mis-matching type names'
+	)
+	async invalidCollectionResourceDocTypename() {
+		await assertTsThrows(
+			join(__dirname, 'examples/collection-resource-wrong-typename.ts'),
+			/Type '"music"' is not assignable to type '"book"'/,
+			'If a type CollectionResourceDoc specifies a type name, resource objects with mis-matching type name will cause type errors'
+		);
+	}
+
+	@test(
+		'CollectionResourceDoc that specifies resource attributes should throw in the presence of resources w/ mis-matching attribute names'
+	)
+	async invalidCollectionResourceDocAttributeNames() {
+		await assertTsThrows(
+			join(__dirname, 'examples/collection-resource-wrong-attributes.ts'),
+			/'foo' does not exist in type 'AttributesObject/,
+			'If a type CollectionResourceDoc specifies attributes, resource objects with mis-matching attribute names will cause type errors'
+		);
+	}
+	@test(
+		'CollectionResourceDoc that specifies resource attributes should throw in the presence of resources w/ mis-matching attribute types'
+	)
+	async invalidCollectionResourceDocAttributeTypes() {
+		await assertTsThrows(
+			join(__dirname, 'examples/collection-resource-wrong-attribute-types.ts'),
+			/Type 'string' is not assignable to type 'number'/,
+			'If a type CollectionResourceDoc specifies attributes, resource objects with mis-matching attribute types will cause type errors'
+		);
+	}
+}

--- a/tests/toplevel/examples/bad-collection-doc.ts
+++ b/tests/toplevel/examples/bad-collection-doc.ts
@@ -1,0 +1,6 @@
+import * as JSONAPI from '../../../index';
+let doc: JSONAPI.DocWithData<JSONAPI.CollectionPrimaryData> = {
+	data: {
+		type: 'foo'
+	}
+};

--- a/tests/toplevel/examples/bad-collection-doc.ts
+++ b/tests/toplevel/examples/bad-collection-doc.ts
@@ -1,5 +1,5 @@
 import * as JSONAPI from '../../../index';
-let doc: JSONAPI.DocWithData<JSONAPI.CollectionPrimaryData> = {
+let doc: JSONAPI.DocWithData<JSONAPI.ResourceObject[]> = {
 	data: {
 		type: 'foo'
 	}

--- a/tests/toplevel/examples/bad-meta-object.ts
+++ b/tests/toplevel/examples/bad-meta-object.ts
@@ -1,4 +1,4 @@
-import JSONAPI from '../../../index';
+import * as JSONAPI from '../../../index';
 let doc: JSONAPI.Document = {
 	jsonapi: { meta: '5' },
 	errors: []

--- a/tests/toplevel/examples/bad-single-resource-doc.ts
+++ b/tests/toplevel/examples/bad-single-resource-doc.ts
@@ -1,0 +1,8 @@
+import * as JSONAPI from '../../../index';
+let doc: JSONAPI.DocWithData<JSONAPI.SinglePrimaryData> = {
+	data: [
+		{
+			type: 'foo'
+		}
+	]
+};

--- a/tests/toplevel/examples/bad-single-resource-doc.ts
+++ b/tests/toplevel/examples/bad-single-resource-doc.ts
@@ -1,5 +1,5 @@
 import * as JSONAPI from '../../../index';
-let doc: JSONAPI.DocWithData<JSONAPI.SinglePrimaryData> = {
+let doc: JSONAPI.DocWithData<JSONAPI.ResourceObject> = {
 	data: [
 		{
 			type: 'foo'

--- a/tests/toplevel/examples/collection-resource-wrong-attribute-types.ts
+++ b/tests/toplevel/examples/collection-resource-wrong-attribute-types.ts
@@ -1,0 +1,18 @@
+import { CollectionResourceDoc } from '../../../index';
+
+let d: CollectionResourceDoc<
+	'book',
+	{ title: string; author: string; chapters: number }
+>;
+d = {
+	data: [
+		{
+			type: 'book',
+			attributes: {
+				title: 'Great Expectations',
+				chapters: '12',
+				author: 'F. Scott Fitzgerald'
+			}
+		}
+	]
+};

--- a/tests/toplevel/examples/collection-resource-wrong-attributes.ts
+++ b/tests/toplevel/examples/collection-resource-wrong-attributes.ts
@@ -1,0 +1,18 @@
+import { CollectionResourceDoc } from '../../../index';
+
+let d: CollectionResourceDoc<
+	'book',
+	{ title: string; author: string; chapters: number }
+>;
+d = {
+	data: [
+		{
+			type: 'book',
+			attributes: {
+				foo: 'Great Expectations',
+				bar: 12,
+				baz: 'F. Scott Fitzgerald'
+			}
+		}
+	]
+};

--- a/tests/toplevel/examples/collection-resource-wrong-typename.ts
+++ b/tests/toplevel/examples/collection-resource-wrong-typename.ts
@@ -1,0 +1,15 @@
+import { CollectionResourceDoc } from '../../../index';
+
+let d: CollectionResourceDoc<'book'>;
+d = {
+	data: [
+		{
+			type: 'music',
+			attributes: {
+				foo: 'Great Expectations',
+				bar: 12,
+				baz: 'F. Scott Fitzgerald'
+			}
+		}
+	]
+};

--- a/tests/toplevel/examples/only-boolean.ts
+++ b/tests/toplevel/examples/only-boolean.ts
@@ -1,2 +1,2 @@
-import JSONAPI from '../../../index';
+import * as JSONAPI from '../../../index';
 let doc: JSONAPI.Document = true;

--- a/tests/toplevel/examples/only-jsonapi.ts
+++ b/tests/toplevel/examples/only-jsonapi.ts
@@ -1,4 +1,4 @@
-import JSONAPI from '../../../index';
+import * as JSONAPI from '../../../index';
 let doc: JSONAPI.Document = {
 	jsonapi: { version: '1.0' }
 };

--- a/tests/toplevel/examples/only-number.ts
+++ b/tests/toplevel/examples/only-number.ts
@@ -1,2 +1,2 @@
-import JSONAPI from '../../../index';
+import * as JSONAPI from '../../../index';
 let doc: JSONAPI.Document = 6;

--- a/tests/toplevel/examples/only-string.ts
+++ b/tests/toplevel/examples/only-string.ts
@@ -1,2 +1,2 @@
-import JSONAPI from '../../../index';
+import * as JSONAPI from '../../../index';
 let doc: JSONAPI.Document = '';

--- a/tests/toplevel/examples/single-resource-wrong-attribute-types.ts
+++ b/tests/toplevel/examples/single-resource-wrong-attribute-types.ts
@@ -1,0 +1,16 @@
+import { SingleResourceDoc } from '../../../index';
+
+let d: SingleResourceDoc<
+	'book',
+	{ title: string; author: string; chapters: number }
+>;
+d = {
+	data: {
+		type: 'book',
+		attributes: {
+			title: 'Great Expectations',
+			chapters: '12',
+			author: 'F. Scott Fitzgerald'
+		}
+	}
+};

--- a/tests/toplevel/examples/single-resource-wrong-attributes.ts
+++ b/tests/toplevel/examples/single-resource-wrong-attributes.ts
@@ -1,0 +1,16 @@
+import { SingleResourceDoc } from '../../../index';
+
+let d: SingleResourceDoc<
+	'book',
+	{ title: string; author: string; chapters: number }
+>;
+d = {
+	data: {
+		type: 'book',
+		attributes: {
+			foo: 'Great Expectations',
+			bar: 12,
+			baz: 'F. Scott Fitzgerald'
+		}
+	}
+};

--- a/tests/toplevel/examples/single-resource-wrong-typename.ts
+++ b/tests/toplevel/examples/single-resource-wrong-typename.ts
@@ -1,0 +1,13 @@
+import { SingleResourceDoc } from '../../../index';
+
+let d: SingleResourceDoc<'book'>;
+d = {
+	data: {
+		type: 'music',
+		attributes: {
+			foo: 'Great Expectations',
+			bar: 12,
+			baz: 'F. Scott Fitzgerald'
+		}
+	}
+};

--- a/tests/toplevel/main.test.ts
+++ b/tests/toplevel/main.test.ts
@@ -1,9 +1,8 @@
-import { suite, test, slow, timeout, only } from 'mocha-typescript';
-import { assert } from 'chai';
-import { check, checkDirectory } from 'typings-tester';
+import { suite, test } from 'mocha-typescript';
 import { join } from 'path';
 import { assertTsThrows } from '../helpers';
 import * as JSONAPI from '../../index';
+import { SinglePrimaryData } from '../../index';
 
 @suite(
 	'Top-Level Document Tests: A JSON object MUST be at the root of every JSON API request and response containing data.'
@@ -35,6 +34,7 @@ class TopLevelDocument {
 			'number is not a valid top-level document'
 		);
 	}
+
 	@test('only having a "jsonapi" property is not a top-level document')
 	async onlyJsonApiInfo() {
 		await assertTsThrows(
@@ -154,5 +154,67 @@ class TopLevelDocument {
 				}
 			]
 		};
+	}
+
+	@test('Document with data')
+	validDocWithData() {
+		// Array case
+		let d: JSONAPI.DocWithData = {
+			data: [
+				{
+					type: 'foo'
+				}
+			]
+		};
+		// Object case
+		d = {
+			data: {
+				type: 'foo'
+			}
+		};
+	}
+
+	@test('Document with single resource data')
+	validDocWithSingleResourceData() {
+		// single resource case
+		let d: JSONAPI.DocWithData<SinglePrimaryData> = {
+			data: {
+				type: 'foo'
+			}
+		};
+	}
+
+	@test(
+		'DocWithData<SinglePrimaryData> will throw type error on a collection document'
+	)
+	async invalidDocWithSingleResourceData() {
+		await assertTsThrows(
+			join(__dirname, 'examples/bad-single-resource-doc.ts'),
+			/is not assignable to type 'DocWithData<SinglePrimaryData>'/,
+			'number is not a valid top-level document'
+		);
+	}
+
+	@test('Document with multi resource data')
+	validDocWithCollectionResourceData() {
+		// single resource case
+		let d: JSONAPI.DocWithData<JSONAPI.CollectionPrimaryData> = {
+			data: [
+				{
+					type: 'foo'
+				}
+			]
+		};
+	}
+
+	@test(
+		'DocWithData<CollectionPrimaryData> will throw type error on a single-resource document'
+	)
+	async invalidDocWithCollectionResourceData() {
+		await assertTsThrows(
+			join(__dirname, 'examples/bad-collection-doc.ts'),
+			/is not assignable to type 'DocWithData<CollectionPrimaryData>'/,
+			'number is not a valid top-level document'
+		);
 	}
 }

--- a/tests/toplevel/main.test.ts
+++ b/tests/toplevel/main.test.ts
@@ -1,8 +1,9 @@
 import { suite, test } from 'mocha-typescript';
 import { join } from 'path';
 import { assertTsThrows } from '../helpers';
-import * as JSONAPI from '../../index';
-import { SinglePrimaryData } from '../../index';
+import { DocWithData, Document } from '../..';
+import './collection-resource-doc';
+import './single-resource-doc';
 
 @suite(
 	'Top-Level Document Tests: A JSON object MUST be at the root of every JSON API request and response containing data.'
@@ -45,7 +46,7 @@ class TopLevelDocument {
 	}
 	@test('A few examples of valid documents')
 	validEmptyDocuments() {
-		let doc: JSONAPI.Document;
+		let doc: Document;
 		// Only errors
 		doc = { errors: [] };
 		// Only data
@@ -159,7 +160,7 @@ class TopLevelDocument {
 	@test('Document with data')
 	validDocWithData() {
 		// Array case
-		let d: JSONAPI.DocWithData = {
+		let d: DocWithData = {
 			data: [
 				{
 					type: 'foo'
@@ -172,49 +173,5 @@ class TopLevelDocument {
 				type: 'foo'
 			}
 		};
-	}
-
-	@test('Document with single resource data')
-	validDocWithSingleResourceData() {
-		// single resource case
-		let d: JSONAPI.DocWithData<SinglePrimaryData> = {
-			data: {
-				type: 'foo'
-			}
-		};
-	}
-
-	@test(
-		'DocWithData<SinglePrimaryData> will throw type error on a collection document'
-	)
-	async invalidDocWithSingleResourceData() {
-		await assertTsThrows(
-			join(__dirname, 'examples/bad-single-resource-doc.ts'),
-			/is not assignable to type 'DocWithData<SinglePrimaryData>'/,
-			'number is not a valid top-level document'
-		);
-	}
-
-	@test('Document with multi resource data')
-	validDocWithCollectionResourceData() {
-		// single resource case
-		let d: JSONAPI.DocWithData<JSONAPI.CollectionPrimaryData> = {
-			data: [
-				{
-					type: 'foo'
-				}
-			]
-		};
-	}
-
-	@test(
-		'DocWithData<CollectionPrimaryData> will throw type error on a single-resource document'
-	)
-	async invalidDocWithCollectionResourceData() {
-		await assertTsThrows(
-			join(__dirname, 'examples/bad-collection-doc.ts'),
-			/is not assignable to type 'DocWithData<CollectionPrimaryData>'/,
-			'number is not a valid top-level document'
-		);
 	}
 }

--- a/tests/toplevel/single-resource-doc.ts
+++ b/tests/toplevel/single-resource-doc.ts
@@ -1,0 +1,95 @@
+import { suite, test } from 'mocha-typescript';
+import { join } from 'path';
+import { assertTsThrows } from '../helpers';
+import { DocWithData, ResourceObject, SingleResourceDoc } from '../..';
+
+@suite(
+	'Single-Resource Document Tests: Tests for top-level docs that should contain a single resource.'
+)
+class SingleResourceDocTests {
+	@test('Document with single resource data')
+	validDocWithSingleResourceData() {
+		// single resource case
+		let d: DocWithData<ResourceObject> = {
+			data: {
+				type: 'foo'
+			}
+		};
+	}
+
+	@test(
+		'DocWithData<SinglePrimaryData> will throw type error on a collection document'
+	)
+	async invalidDocWithSingleResourceData() {
+		await assertTsThrows(
+			join(__dirname, 'examples/bad-single-resource-doc.ts'),
+			/is not assignable to type 'DocWithData<ResourceObject/,
+			'Doc that should contain a single resource throws if data: is an array'
+		);
+	}
+
+	@test('SingleResourceDoc for specific type w/o specific attributes')
+	async validDocWithSpecificSingleResourceType() {
+		let d: SingleResourceDoc<'book'>;
+		d = {
+			data: {
+				type: 'book',
+				attributes: {
+					foo: 'Great Expectations',
+					bar: 12,
+					baz: 'F. Scott Fitzgerald'
+				}
+			}
+		};
+	}
+
+	@test('SingleResourceDoc for specific type w/ specific attributes')
+	async validDocWithSpecificTypeAndSingleResourceData() {
+		let d: SingleResourceDoc<
+			'book',
+			{ title: string; author: string; chapters: number }
+		>;
+		d = {
+			data: {
+				type: 'book',
+				attributes: {
+					title: 'Great Expectations',
+					chapters: 12,
+					author: 'F. Scott Fitzgerald'
+				}
+			}
+		};
+	}
+
+	@test(
+		'SingleResourceDoc that specifies resource type name should throw in the presence of resources w/ mis-matching type names'
+	)
+	async invalidSingleResourceDocTypename() {
+		await assertTsThrows(
+			join(__dirname, 'examples/single-resource-wrong-typename.ts'),
+			/Type '"music"' is not assignable to type '"book"'/,
+			'If a type SingleResourceDoc specifies a type name, resource objects with mis-matching type name will cause type errors'
+		);
+	}
+
+	@test(
+		'SingleResourceDoc that specifies resource attributes should throw in the presence of resources w/ mis-matching attribute names'
+	)
+	async invalidSingleResourceAttributeNames() {
+		await assertTsThrows(
+			join(__dirname, 'examples/single-resource-wrong-attributes.ts'),
+			/'foo' does not exist in type 'AttributesObject/,
+			'If a type SingleResourceDoc specifies attributes, resource objects with mis-matching attribute names will cause type errors'
+		);
+	}
+	@test(
+		'SingleResourceDoc that specifies resource attributes should throw in the presence of resources w/ mis-matching attribute types'
+	)
+	async invalidSingleResourceAttributeTypes() {
+		await assertTsThrows(
+			join(__dirname, 'examples/single-resource-wrong-attribute-types.ts'),
+			/Type 'string' is not assignable to type 'number'/,
+			'If a type SingleResourceDoc specifies attributes, resource objects with mis-matching attribute types will cause type errors'
+		);
+	}
+}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,27 +1,12 @@
 {
+  "extends": "../tsconfig",
   "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
-    "experimentalDecorators": true,
-    "noImplicitAny": true,
-    "lib": [
-      "es2015"
-    ],
-    "noImplicitThis": true,
-    "allowSyntheticDefaultImports": true,
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
-    "sourceMap": true,
-    "noUnusedParameters": true,
-    "noEmitOnError": true,
-    "noEmit": true
+    "experimentalDecorators": true
   },
-  "exclude": [
-    "..node_modules/**/*",
-    "helpers.ts",
-    "**/*test.ts"
-  ],
   "include": [
-    "**/*.ts"
+    "**/*.test.ts"
+  ],
+  "exclude": [
+    "**/examples/*.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
 		"lib": [
 			"es2015"
 		],
+		"experimentalDecorators": true,
 		"noImplicitThis": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
 	"compilerOptions": {
 		"target": "es6",
 		"module": "commonjs",
-		"experimentalDecorators": true,
 		"noImplicitAny": true,
 		"lib": [
 			"es2015"
@@ -16,11 +15,10 @@
 		"noEmit": true
 	},
 	"exclude": [
-		"node_modules/**/*"
+		"node_modules/**/*",
+		"test/**/*"
 	],
 	"include": [
-		"./index.ts",
-		"./tests/helpers.ts",
-		"./tests/**/*test.ts"
+		"index.ts"
 	]
 }


### PR DESCRIPTION
All existing functionality should continue to work. Additionally, consumers may now validate against documents that contain specific types of data

```ts
let d: SingleResourceDoc< 'book', { title: string; author: string; chapters: number }> = {
	data: {
		type: 'book',
		attributes: {
			title: 'Great Expectations',
			chapters: 12,
			author: 'F. Scott Fitzgerald'
		}
	}
};
```