### PR TITLE
Add META to DocBase

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,10 @@ import * as JSON from 'json-typescript';
 
 export type MetaObject = JSON.Object;
 
+/**
+ * this type is no longer required, as the meta has been moved to the DocBase
+ * this type can be safely removed in future versions
+ */
 export interface DocWithMeta extends DocBase {
 	meta: MetaObject; // a meta object that contains non-standard meta-information.
 }
@@ -33,6 +37,7 @@ export interface DocWithErrors extends DocBase {
 export interface DocBase {
 	jsonapi?: ImplementationInfo;
 	links?: Links | PaginationLinks;
+	meta?: MetaObject; // a meta object that contains non-standard meta-information.
 }
 
 export type Document = DocWithErrors | DocWithMeta | DocWithData;

--- a/type-tests/meta.test.ts
+++ b/type-tests/meta.test.ts
@@ -1,0 +1,29 @@
+import * as JSONAPI from '..';
+
+// Array case
+let d1: JSONAPI.DocWithData = {
+	data: [
+		{
+			type: 'foo'
+		}
+	],
+	meta: {
+		foo: 'bar'
+	}
+};
+// Object case
+d1 = {
+	data: {
+		type: 'foo'
+	},
+	meta: {
+		foo: 'bar'
+	}
+};
+
+// Document only with MetaData
+const d: JSONAPI.DocBase = {
+	meta: {
+		foo: 'bar'
+	}
+};


### PR DESCRIPTION
This PR basically adds the same functionality as described in #37 (which fixes #36). However, this PR adds the required tests.

In my opinion, the `DocWithMeta` type is no longer required, if we add the optional `meta?: MetaObject` to the `DocBase` type.

Thank you for reviewing and all the best